### PR TITLE
Create .env.example with documented variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# ============================================================
+# TrustLock Environment Variables
+# ============================================================
+#
+# Copy this file to .env and fill in your values:
+#
+#   cp .env.example .env
+#
+# NEVER commit .env — it is listed in .gitignore.
+# This .env.example file IS safe to commit (no real secrets).
+# ============================================================
+
+# ── Network ──────────────────────────────────────────────────
+# Which Stacks network to target.
+# Valid values: simnet | testnet | mainnet
+STACKS_NETWORK=simnet
+
+# ── Deployer ─────────────────────────────────────────────────
+# The STX address that deployed (or will deploy) the contracts.
+# On simnet this is the default deployer from Devnet.toml.
+# On testnet/mainnet, use the address derived from your mnemonic.
+#
+# Examples:
+#   simnet:  ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+#   testnet: ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0
+#   mainnet: SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193
+DEPLOYER_ADDRESS=ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+
+# ── API ──────────────────────────────────────────────────────
+# Hiro API base URL for the target network.
+# Defaults below — override only if using a custom node.
+#
+# simnet:  (not applicable — tests use clarinet-sdk)
+# testnet: https://api.testnet.hiro.so
+# mainnet: https://api.mainnet.hiro.so
+API_URL=https://api.testnet.hiro.so
+
+# ── Frontend (future) ───────────────────────────────────────
+# These will be used when the frontend is built out.
+# Uncomment and fill in as needed.
+#
+# NEXT_PUBLIC_NETWORK=testnet
+# NEXT_PUBLIC_API_URL=https://api.testnet.hiro.so
+# NEXT_PUBLIC_CONTRACT_ADDRESS=ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ settings/Devnet.toml
 # May contain API keys, wallet seeds, deployment secrets
 .env
 .env.*
+!.env.example
 .env.local
 .env.production
 .env.development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,10 @@ cd trustlock
 # Install dependencies
 npm install
 
+# Set up environment variables
+cp .env.example .env
+# Edit .env with your network and deployer address
+
 # Install pre-commit hooks
 pip install pre-commit
 pre-commit install

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ See [Security Policy](SECURITY.md) for details.
 # Install dependencies
 npm install
 
+# Set up environment variables
+cp .env.example .env
+
 # Check contracts
 clarinet check
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,6 +33,10 @@ cd trustlock
 # Install dependencies
 npm install
 
+# Set up environment variables
+cp .env.example .env
+# Edit .env with your values (see comments in the file)
+
 # Verify setup
 clarinet check
 npm test


### PR DESCRIPTION
Closes #20 - Added .env.example with STACKS_NETWORK, DEPLOYER_ADDRESS, and API_URL. Whitelisted it in gitignore and referenced it in quickstart, README, and contributing guide.